### PR TITLE
POTD_16_OCT_2024_TwoSwaps

### DIFF
--- a/POTD_16_OCT_2024_TwoSwaps.cpp
+++ b/POTD_16_OCT_2024_TwoSwaps.cpp
@@ -1,0 +1,27 @@
+class Solution { 
+public: 
+void doOneSwap(int &n, vector<int> &arr) { 
+  for (int i = 0; i < n; i++) { 
+    if (arr[i] != i + 1) { 
+      for (int j = i + 1; j < n; j++) { 
+        if (arr[j] == i + 1) { 
+          swap(arr[i], arr[j]); 
+          return; 
+        } 
+      } 
+    } 
+  } 
+} 
+bool checkSorted(vector<int> &arr) { 
+  int n = arr.size(); 
+  int misMatch = 0; 
+  for (int i = 0; i < n; i++) { 
+    if (arr[i] != i + 1) misMatch++; } 
+  if (n == 1) return false; 
+  if (misMatch == 0 || misMatch == 3) return true; if (misMatch != 4) return false; 
+  doOneSwap(n, arr); 
+  doOneSwap(n, arr); 
+  for (int i = 0; i < n; i++) { 
+    if (arr[i] != i + 1) 
+      return false; } 
+  return true; } };


### PR DESCRIPTION
Examples:
Input: arr = [4, 3, 2, 1]
Output: true
Explanation: First, swap arr[0] and arr[3]. The array becomes [1, 3, 2, 4]. Then, swap arr[1] and arr[2]. The array becomes [1, 2, 3, 4], which is sorted.Input: arr = [4, 3, 1, 2] Output: false
Explanation: It is not possible to sort the array with exactly two swaps. Input: arr = [1, 2, 3, 4]
Output: true
Explanation: It is already sorted array, so no swaps needed. Constraints:
1 ≤ arr.size() ≤ 106
1 ≤ arr[i] ≤ arr.size()


## Description

Please include a summary of the changes and the related issue(s) this pull request addresses. Include any relevant context or background information.

Fixes: #[issue_number] (replace with the issue number, if applicable)

Use [x] to represent a checked (ticked) box.✅
Use [ ] to represent an unchecked box.❌

## Type of Change

- [ ] Question Added
- [ ] Solution Added
- [ ] Other (please specify):


## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [ ] My changes generate no new warnings.
- [ ] I have added tests to cover my changes (if applicable).
- [ ] All new and existing tests pass.

## Additional Notes

Please add any other information that is relevant to this pull request, including potential risks, alternative solutions considered, or future improvements.
